### PR TITLE
Get comment by id functionality is ready to merge

### DIFF
--- a/practice-app/app/comment.py
+++ b/practice-app/app/comment.py
@@ -119,5 +119,7 @@ def getCommentByID(post_id,comment_id):
     if len(session.query(Comment).filter(Comment.commentId==comment_id).all())==0: ## check if the comment exists
         return make_response(jsonify({'error': 'There is no comment with given ID'}), 404)
     comment = session.query(Comment).filter(Comment.commentId==comment_id).first() ## if so, select the comment by id
+    if int(comment.postID) != post_id: ##check if the comment is comment of given event
+        return make_response(jsonify({'error': 'Post has no comment with the given ID'}), 404)
     comment_dict = {c.name: str(getattr(comment, c.name)) for c in comment.__table__.columns} ## convert comment object to dictionary
     return jsonify(comment_dict), 200 ## convert to json and make response

--- a/practice-app/app/comment.py
+++ b/practice-app/app/comment.py
@@ -33,9 +33,9 @@ def postComment(post_id):
 def getCommentByID(post_id,comment_id):
     if len(session.query(Eventpost).filter(Eventpost.postID==post_id).all())==0: ## check if the event exists
         return make_response(jsonify({'error': 'There is no post with given ID'}), 404)
-    if len(session.query(Comment).filter(Comment.commentId==comment_id).all())==0: ## check if the comment exists
+    if len(session.query(Comment).filter(Comment.commentID==comment_id).all())==0: ## check if the comment exists
         return make_response(jsonify({'error': 'There is no comment with given ID'}), 404)
-    comment = session.query(Comment).filter(Comment.commentId==comment_id).first() ## if so, select the comment by id
+    comment = session.query(Comment).filter(Comment.commentID==comment_id).first() ## if so, select the comment by id
     if int(comment.postID) != post_id: ##check if the comment is comment of given event
         return make_response(jsonify({'error': 'Post has no comment with the given ID'}), 404)
     comment_dict = {c.name: str(getattr(comment, c.name)) for c in comment.__table__.columns} ## convert comment object to dictionary

--- a/practice-app/app/comment.py
+++ b/practice-app/app/comment.py
@@ -111,3 +111,13 @@ def postComment(post_id):
     session.add(Comment(**newComment))
     session.commit()
     return jsonify(newComment), 201
+
+@app.route("/api/v1.0/events/<int:post_id>/comments/<int:comment_id>",methods=["GET"])
+def getCommentByID(post_id,comment_id):
+    if len(session.query(eventpost).filter(eventpost.postID==post_id).all())==0: ## check if the event exists
+        return make_response(jsonify({'error': 'There is no post with given ID'}), 404)
+    if len(session.query(Comment).filter(Comment.commentId==comment_id).all())==0: ## check if the comment exists
+        return make_response(jsonify({'error': 'There is no comment with given ID'}), 404)
+    comment = session.query(Comment).filter(Comment.commentId==comment_id).first() ## if so, select the comment by id
+    comment_dict = {c.name: str(getattr(comment, c.name)) for c in comment.__table__.columns} ## convert comment object to dictionary
+    return jsonify(comment_dict), 200 ## convert to json and make response


### PR DESCRIPTION
I have completed the get method for individual comments. The method functions at `/api/v1.0/events/<int:post_id>/comments/<int:comment_id>`. It takes an event_id and a comment_id from the path, and first checks if these id values correspond to an event and a comment respectively. If not, 404 code is returned with appropriate message. If match is successful, another check is done for the equality of the event_id and the event_id of the comment. If this is also successful, comment is returned as a json object.