### PR TITLE
Improved home page titles and event card layout

### DIFF
--- a/frontend/src/Views/Home/EventCard.js
+++ b/frontend/src/Views/Home/EventCard.js
@@ -1,4 +1,4 @@
-import {Card, CardActionArea, CardContent, CardMedia, Grid, Typography} from "@mui/material";
+import {Card, CardActionArea, CardContent, CardMedia, Grid, Stack, Typography} from "@mui/material";
 import * as React from "react";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
@@ -8,12 +8,13 @@ import DateRangeIcon from '@mui/icons-material/DateRange';
 import GroupIcon from '@mui/icons-material/Group';
 import AssessmentIcon from '@mui/icons-material/Assessment';
 export default function EventInfoCard(props){
+    const typoStyle = {fontSize:13,display:"flex", flexDirection: "column", justifyContent: "center"}
     return (
         <Card sx={{ maxWidth: 345 }}  style={{ background: '#dbf0f9', justifyContent: 'center', flexDirection: 'column'}}>
             <CardActionArea>
                 <CardMedia
                     component="img"
-                    height="140"
+                    height="100"
                     image={props.image}
                     alt={props.title}
                 />
@@ -21,32 +22,31 @@ export default function EventInfoCard(props){
                     <Typography gutterBottom align="center" variant="h5" component="div">
                         {props.title}
                     </Typography>
-                    <Grid container spacing={1}>
-                        <Grid item xs={12} md={3}>
-                            <IconButton>
-                                <Avatar src={props.avatar}/>
-                            </IconButton>
-                        </Grid>
-                        <Grid item xs={12} md={3}>
-                            <Typography>
-                                {props.username}
-                            </Typography>
-                        </Grid>
-                    </Grid>
-
-                    <LocationOnIcon/>
-                    <Typography>
-                        {props.location}
-                    </Typography>
-                    <DateRangeIcon/>
-                    <Typography>
-                        {props.date}
-                    </Typography>
-
-                    <GroupIcon/>
-                    <Typography align="justify" variant="body2" color="text.secondary">
+                    <Typography align="center" variant="body2">
                         {props.desc}
                     </Typography>
+                    <Stack spacing={1}>
+                        <Stack spacing={1} direction="row" justifyContent="flex-start">
+                                <IconButton>
+                                    <Avatar  sx={{ width: 24, height: 24 }} src={props.avatar}/>
+                                </IconButton>
+                                <Typography style={typoStyle}>
+                                    {props.username}
+                                </Typography>
+                        </Stack>
+                        <Stack spacing={2} direction="row">
+                            <LocationOnIcon style={{marginLeft:3}}/>
+                            <Typography style={typoStyle}>
+                                {props.location}
+                            </Typography>
+                        </Stack>
+                        <Stack spacing={2} direction="row">
+                            <DateRangeIcon/>
+                            <Typography style={typoStyle}>
+                                {props.date}
+                            </Typography>
+                        </Stack>
+                    </Stack>
                 </CardContent>
             </CardActionArea>
         </Card>

--- a/frontend/src/Views/Home/Home.js
+++ b/frontend/src/Views/Home/Home.js
@@ -21,50 +21,54 @@ function Homepage() {
         getSampleEvents().then(r=>setEvents(r))
             .catch(console.log)
     }, [])
-    return (
-        <div className="Homepage">
-            <h2>Discover Sports</h2>
-            <div style={{
-                display: 'flex',
-                alignItems: 'center'}}>
-                <IconButton style={{marginRight:25,marginLeft: 10}} onClick={() => {
-                    setSportIndex(sportIndex>2?sportIndex-3:0);}}>
-                    <ArrowBackIosIcon/>
-                </IconButton>
-                <Grid container spacing={2} alignItems="stretch">
-                    {sports.slice(sportIndex,sportIndex+3).map(s=>(
-                        <Grid item md={4} style={{display: 'flex'}}>
-                            <SportsInfoCard {...s}/>
-                        </Grid>)
-                    )}
-                </Grid>
-                <IconButton style={{marginRight:10}} onClick={() => {
-                    setSportIndex(sportIndex<9?sportIndex+3:9);}}>
-                    <ArrowForwardIosIcon/>
-                </IconButton>
-            </div>
-            <h2>Browse Events</h2>
-            <div style={{
-                display: 'flex',
-                alignItems: 'center'}}>
-                <IconButton style={{marginRight:25,marginLeft: 10}} onClick={() => {
-                    setEventIndex(eventIndex>2?eventIndex-3:0);}}>
-                    <ArrowBackIosIcon/>
-                </IconButton>
-                <Grid container spacing={2} alignItems="stretch">
-                    {events.slice(eventIndex,eventIndex+3).map(s=>(
-                        <Grid item md={4} style={{display: 'flex'}}>
-                            <EventInfoCard {...s}/>
-                        </Grid>)
-                    )}
-                </Grid>
-                <IconButton style={{marginRight:10}} onClick={() => {
-                    setEventIndex(eventIndex<9?eventIndex+3:9);}}>
-                    <ArrowForwardIosIcon/>
-                </IconButton>
-            </div>
+  return (
+    <div className="Homepage">
+        <h2 style={{ color: "#FF7518", fontFamily: 'Trocchi', fontSize: "30px", fontWeight: "normal", lineHeight: "48px", textAlign: "center", marginTop: 30, marginBottom: 30}}>
+            Discover Sports
+        </h2>
+        <div style={{
+            display: 'flex',
+            alignItems: 'center'}}>
+            <IconButton style={{marginRight:25,marginLeft: 10}} onClick={() => {
+                setSportIndex(sportIndex>2?sportIndex-3:0);}}>
+                <ArrowBackIosIcon/>
+            </IconButton>
+            <Grid container spacing={2} alignItems="stretch">
+                {sports.slice(sportIndex,sportIndex+3).map(s=>(
+                    <Grid item md={4} style={{display: 'flex'}}>
+                        <SportsInfoCard {...s}/>
+                    </Grid>)
+                )}
+            </Grid>
+            <IconButton style={{marginRight:10}} onClick={() => {
+                setSportIndex(sportIndex<9?sportIndex+3:9);}}>
+                <ArrowForwardIosIcon/>
+            </IconButton>
         </div>
-    );
+        <h2 style={{ color: "#FF7518", fontFamily: 'Trocchi', fontSize: "30px", fontWeight: "normal", lineHeight: "48px", textAlign: "center", marginTop: 30, marginBottom: 30}}>
+            Browse Events
+        </h2>
+        <div style={{
+            display: 'flex',
+            alignItems: 'center'}}>
+            <IconButton style={{marginRight:25,marginLeft: 10}} onClick={() => {
+                setEventIndex(eventIndex>2?eventIndex-3:0);}}>
+                <ArrowBackIosIcon/>
+            </IconButton>
+            <Grid container spacing={2} alignItems="stretch">
+                {events.slice(eventIndex,eventIndex+3).map(s=>(
+                    <Grid item md={4} style={{display: 'flex'}}>
+                        <EventInfoCard {...s}/>
+                    </Grid>)
+                )}
+            </Grid>
+            <IconButton style={{marginRight:10}} onClick={() => {
+                setEventIndex(eventIndex<9?eventIndex+3:9);}}>
+                <ArrowForwardIosIcon/>
+            </IconButton>
+        </div>
+    </div>
+  );
 }
 
 export default Homepage;


### PR DESCRIPTION
I aligned the titles and improved them. I also fixed the event card layout. Now, icons and related information are stacked vertically and the description of the event is at the center.


![FireShot Capture 008 -  - localhost](https://user-images.githubusercontent.com/52797716/141699859-b5682775-7f4a-42d4-a64d-7ca5ca87e7b3.png)
