### PR TITLE
[Backend] Privacy settings

### DIFF
--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -59,7 +59,7 @@ class User(AbstractUser):
 
     badges = ArrayField(models.CharField(max_length=30), default=empty_list)
 
-    privacy = models.BooleanField(default=True)
+    privacy = models.BooleanField(default=False)
 
     email = models.EmailField(_('email address'), blank=True, unique=True, error_messages={
             'unique': _("A user with that email address already exists."),

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -4,9 +4,14 @@ from authentication.models import User
 class ProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'first_name', 'last_name',
+        fields = ('id', 'first_name', 'last_name', 'username',
                   'bio', 'fav_sport_1', 'fav_sport_2', 'fav_sport_3',
-                  'location', 'avatar')
-        read_only_fields = ('id',)
+                  'location', 'avatar', 'privacy', 'badges')
+        read_only_fields = ('id', 'username', 'badges')
 
 
+class PrivateProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'avatar', 'privacy')
+        read_only_fields = ('id', 'username')


### PR DESCRIPTION
I have implemented privacy settings in the following way: if a user's privacy is set to True, other users or guests can only see their username and avatar and nothing else. A user can always see every detail of their own profile. Also, this fixes a player's badge array not being shown along with their profile details. (resolves #299 )