### PR TITLE
[Backend] Paginated responses now return the total number of pages

### DIFF
--- a/backend/equipmentposts/views.py
+++ b/backend/equipmentposts/views.py
@@ -11,12 +11,24 @@ from rest_framework import viewsets
 from rest_framework import permissions
 from rest_framework.pagination import PageNumberPagination
 from django.db.models import Q
+from collections import OrderedDict
 
 
 class EquipmentPostsPagination(PageNumberPagination):
     page_size = 10
     page_size_query_param = 'page_size'
     max_page_size = 1000
+
+    def get_paginated_response(self, data):
+        return Response(OrderedDict([
+            ('count', self.page.paginator.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data),
+            ('totalPages', self.page.paginator.num_pages)
+        ]))
+
+
 
 
 class EquipmentViewSet(NestedViewSetMixin, viewsets.ModelViewSet):

--- a/backend/eventposts/views.py
+++ b/backend/eventposts/views.py
@@ -13,12 +13,21 @@ from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from django.db.models import Q, F, Func, IntegerField
 from datetime import datetime
-
+from collections import OrderedDict
 
 class EventPostsPagination(PageNumberPagination):
     page_size = 10
     page_size_query_param = 'page_size'
     max_page_size = 1000
+
+    def get_paginated_response(self, data):
+        return Response(OrderedDict([
+            ('count', self.page.paginator.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data),
+            ('totalPages', self.page.paginator.num_pages)
+        ]))
 
 
 class EventViewSet(NestedViewSetMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
I fixed #371 by overloading the pagination classes' get_paginated_response functions and adding a totalPages attribute in the return value.